### PR TITLE
fix: update the way SortableJS is imported into the library

### DIFF
--- a/angular-legacy-sortable.js
+++ b/angular-legacy-sortable.js
@@ -20,6 +20,8 @@
 })(function (angular, Sortable) {
 	'use strict';
 
+	// Use default import if available
+	Sortable = Sortable.default || Sortable;
 
 	/**
 	 * @typedef   {Object}        ngSortEvent

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "angular-legacy-sortablejs-maintained",
+  "name": "@opengovsg/angular-legacy-sortablejs-maintained",
   "version": "1.0.0",
-  "description": "Angular (legacy) directive for SortableJS.",
+  "description": "Fork of Angular (legacy) directive for SortableJS.",
   "main": "angular-legacy-sortable.js",
   "scripts": {
     "serve:example": "node example/app.js",
@@ -23,7 +23,7 @@
   "bugs": {
     "url": "https://github.com/SortableJS/angular-legacy-sortablejs/issues"
   },
-  "homepage": "https://github.com/SortableJS/angular-legacy-sortablejs#readme",
+  "homepage": "https://github.com/opengovsg/angular-legacy-sortablejs",
   "devDependencies": {
     "express": "^4.15.3",
     "express-static": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-legacy-sortablejs-maintained",
-  "version": "0.6.2",
+  "version": "1.0.0",
   "description": "Angular (legacy) directive for SortableJS.",
   "main": "angular-legacy-sortable.js",
   "scripts": {


### PR DESCRIPTION
Second attempt, this time with the name changed

This is due to a breaking change in SortableJS: SortableJS/Sortable#1728, which causes angular-legacy-sortable to imports SortableJS incorrectly after versions 1.10.0, which leads to it not finding Sortablejs.create.

Also bump package version to `1.0.0` since this fixes a breaking change introduced in `0.6.2`